### PR TITLE
wip - add support for multi appliance - for netcommon

### DIFF
--- a/src/pytest_ansible_network_integration/__init__.py
+++ b/src/pytest_ansible_network_integration/__init__.py
@@ -22,6 +22,7 @@ from .defs import VirshWrapper
 from .exceptions import PytestNetworkError
 from .utils import _github_action_log
 from .utils import _inventory
+from .utils import _inventory_multi
 from .utils import _print
 from .utils import calculate_ports
 from .utils import playbook
@@ -404,6 +405,138 @@ def _appliance_dhcp_address(env_vars: Dict[str, str]) -> Generator[str, None, No
         raise
     finally:
         _github_action_log("::endgroup::")
+
+
+@pytest.fixture(scope="session", name="appliance_dhcp_map")
+def _appliance_dhcp_map(env_vars: Dict[str, str]) -> Generator[Dict[str, str], None, None]:
+    """Provision the lab and collect DHCP addresses for all appliances.
+
+    Returns a mapping of device name to DHCP IP for all devices in the lab.
+    """
+    _github_action_log("::group::Starting lab provisioning (multi-device)")
+    _print("Starting lab provisioning (multi-device)")
+
+    try:
+        if not OPTIONS:
+            raise PytestNetworkError("Missing CML lab options")
+
+        lab_file = OPTIONS.cml_lab
+        if not os.path.exists(lab_file):
+            raise PytestNetworkError(f"Missing lab file '{lab_file}'")
+
+        start = time.time()
+        cml = CmlWrapper(
+            host=env_vars["cml_host"],
+            username=env_vars["cml_ui_user"],
+            password=env_vars["cml_ui_password"],
+        )
+        cml.bring_up(file=lab_file)
+        lab_id = cml.current_lab_id
+        logger.debug("Lab ID: %s", lab_id)
+
+        virsh = VirshWrapper(
+            host=env_vars["cml_host"],
+            user=env_vars["cml_ssh_user"],
+            password=env_vars["cml_ssh_password"],
+            port=int(env_vars["cml_ssh_port"]),
+        )
+
+        wait_extra_time = OPTIONS.wait_extra
+        wait_seconds = 0
+        if wait_extra_time:
+            try:
+                wait_seconds = int(wait_extra_time)
+            except ValueError:
+                logger.warning(
+                    "Invalid wait_extra value: '%s'. Expected an integer. Skipping extra wait.",
+                    wait_extra_time,
+                )
+                wait_seconds = 0
+
+        try:
+            device_to_ip = virsh.get_dhcp_leases(lab_id, wait_seconds)
+        except PytestNetworkError as exc:
+            logger.error("Failed to get DHCP leases for the appliances")
+            virsh.close()
+            cml.remove()
+            raise PytestNetworkError("Failed to get DHCP leases for the appliances") from exc
+
+        end = time.time()
+        elapsed = end - start
+        _print(f"Elapsed time to provision (multi): {elapsed} seconds")
+        logger.info("Elapsed time to provision (multi): %s seconds", elapsed)
+
+    except PytestNetworkError as exc:
+        logger.error("Failed to provision lab (multi): %s", exc)
+        _github_action_log("::endgroup::")
+        raise
+
+    finally:
+        virsh.close()
+        _github_action_log("::endgroup::")
+
+    yield device_to_ip
+
+    _github_action_log("::group::Removing lab (multi)")
+    try:
+        cml.remove()
+    except PytestNetworkError as exc:
+        logger.error("Failed to remove lab (multi): %s", exc)
+        raise
+    finally:
+        _github_action_log("::endgroup::")
+
+
+@pytest.fixture
+def ansible_project_multi(
+    appliance_dhcp_map: Dict[str, str],
+    env_vars: Dict[str, str],
+    integration_test_path: Path,
+    tmp_path: Path,
+) -> AnsibleProject:
+    """Build an Ansible project for all discovered appliances.
+
+    Creates a multi-host inventory using all DHCP leases discovered.
+    """
+    logger.info("Building the Ansible project for multiple devices")
+
+    inventory = _inventory_multi(
+        host=env_vars["cml_host"],
+        device_to_ip=appliance_dhcp_map,
+        network_os=env_vars["network_os"],
+        username=env_vars["device_username"],
+        password=env_vars["device_password"],
+    )
+    logger.debug("Generated multi-host inventory: %s", inventory)
+
+    inventory_path = tmp_path / "inventory.json"
+    with inventory_path.open(mode="w", encoding="utf-8") as fh:
+        json.dump(inventory, fh)
+    logger.debug("Inventory written to %s", inventory_path)
+
+    playbook_contents = playbook(hosts="all", role=str(integration_test_path))
+    playbook_path = tmp_path / "site.json"
+    with playbook_path.open(mode="w", encoding="utf-8") as fh:
+        json.dump(playbook_contents, fh)
+    logger.debug("Playbook written to %s", playbook_path)
+
+    _print(f"Inventory path: {inventory_path}")
+    _print(f"Playbook path: {playbook_path}")
+
+    project = AnsibleProject(
+        collection_doc_cache=tmp_path / "collection_doc_cache.db",
+        directory=tmp_path,
+        inventory=inventory_path,
+        log_file=Path.home() / "test_logs" / f"{integration_test_path.name}.log",
+        playbook=playbook_path,
+        playbook_artifact=Path.home()
+        / "test_logs"
+        / "{playbook_status}"
+        / f"{integration_test_path.name}.json",
+        role=integration_test_path.name,
+    )
+    logger.info("Ansible multi-host project created successfully")
+    return project
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:

--- a/src/pytest_ansible_network_integration/defs.py
+++ b/src/pytest_ansible_network_integration/defs.py
@@ -300,11 +300,54 @@ class VirshWrapper:
             logger.info("Done waiting, starting to find IPs")
 
         if len(ips) > 1:
-            logger.error("Found more than one IP: %s", ips)
+            logger.error("SSSSSSSSSSSSSSSSS Found more than one IP: %s", ips)
             raise PytestNetworkError("Found more than one IP")
 
         logger.info("DHCP lease IP found: %s", ips[0])
         return ips[0]
+
+    def get_dhcp_leases(self, current_lab_id: str, wait_extra: int) -> Dict[str, str]:
+        """Get DHCP leases for all devices in the specified lab.
+
+        :param current_lab_id: The current lab ID.
+        :param wait_extra: Extra seconds to wait before resolving leases.
+        :raises PytestNetworkError: If no leases can be found.
+        :return: Mapping of device name to its IP address.
+        """
+        logger.info("Getting all current lab domains from virsh")
+        domains = self._find_current_lab_domains(current_lab_id, 20)
+
+        if wait_extra:
+            logger.info("Waiting for extra %s seconds before resolving leases", wait_extra)
+            time.sleep(wait_extra)
+
+        device_to_ip: Dict[str, str] = {}
+        for domain in domains:
+            try:
+                device_name = domain["domain"]["name"]
+            except KeyError as e:
+                logger.error("Failed to extract device name from domain: %s", e)
+                raise PytestNetworkError(f"Failed to extract device name: {e}") from e
+
+            macs = self._extract_macs(domain)
+            ips = self._find_dhcp_lease(macs, 200)
+
+            if not ips:
+                logger.error("No IP found for device '%s'", device_name)
+                raise PytestNetworkError(f"No IP found for device '{device_name}'")
+
+            if len(ips) > 1:
+                logger.warning(
+                    "Multiple IPs found for device '%s' (MACs: %s), choosing first: %s",
+                    device_name,
+                    macs,
+                    ips,
+                )
+
+            device_to_ip[device_name] = ips[0]
+
+        logger.info("Resolved DHCP leases for devices: %s", device_to_ip)
+        return device_to_ip
 
     def _find_current_lab(self, current_lab_id: str, max_attempts: int = 20) -> Dict[str, Any]:
         """Find the current lab by its ID.
@@ -349,6 +392,60 @@ class VirshWrapper:
 
         logger.error("Could not find current lab after %s attempts", attempt)
         raise PytestNetworkError("Could not find current lab")
+
+    def _find_current_lab_domains(
+        self, current_lab_id: str, max_attempts: int = 20
+    ) -> List[Dict[str, Any]]:
+        """Find all domains for the current lab by its ID.
+
+        Iterates over all virsh domains and collects those whose XML includes the
+        given lab ID. Retries up to max_attempts times.
+
+        :param current_lab_id: The current lab ID.
+        :param max_attempts: Maximum attempts to discover lab domains.
+        :raises PytestNetworkError: If no domains are found for the lab.
+        :return: A list of domain XML dicts.
+        """
+        attempt = 0
+        while attempt < max_attempts:
+            logger.info("Attempt %s to find all current lab domains", attempt)
+            stdout, _stderr = self.ssh.execute("sudo virsh list --all")
+            logger.debug("virsh list output: %s", stdout)
+            if _stderr:
+                logger.error("virsh list stderr: %s", _stderr)
+
+            virsh_matches = [re.match(r"^\s(?P<id>\d+)", line) for line in stdout.splitlines()]
+            if not any(virsh_matches):
+                logger.error("No matching virsh IDs found in the output")
+                raise PytestNetworkError("No matching virsh IDs found")
+
+            try:
+                virsh_ids = [
+                    virsh_match.groupdict()["id"] for virsh_match in virsh_matches if virsh_match
+                ]
+            except KeyError as e:
+                error_message = f"Failed to extract virsh IDs: {e}"
+                logger.error(error_message)
+                raise PytestNetworkError(error_message) from e
+
+            matched_domains: List[Dict[str, Any]] = []
+            for virsh_id in virsh_ids:
+                stdout, _stderr = self.ssh.execute(f"sudo virsh dumpxml {virsh_id}")
+                if current_lab_id in stdout:
+                    logger.debug(
+                        "Found lab %s in virsh dumpxml for ID %s", current_lab_id, virsh_id
+                    )
+                    xmltodict_data = xmltodict.parse(stdout)
+                    matched_domains.append(xmltodict_data)  # type: ignore
+
+            if matched_domains:
+                return matched_domains
+
+            attempt += 1
+            time.sleep(5)
+
+        logger.error("Could not find any domains for current lab after %s attempts", attempt)
+        raise PytestNetworkError("Could not find any domains for current lab")
 
     def _extract_macs(self, current_lab: Dict[str, Any]) -> List[str]:
         """Extract MAC addresses from the current lab.
@@ -408,7 +505,7 @@ class VirshWrapper:
                 return ips
 
             attempt += 1
-            time.sleep(10)
+            time.sleep(400)
 
         logger.error("Could not find IPs after %s attempts", attempt)
         raise PytestNetworkError("Could not find IPs")

--- a/src/pytest_ansible_network_integration/utils.py
+++ b/src/pytest_ansible_network_integration/utils.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Mapping
 
 
 def _print(message: str) -> None:
@@ -65,6 +66,47 @@ def _inventory(
         }
     }
     return inventory
+
+
+def _inventory_multi(
+    host: str,
+    device_to_ip: Mapping[str, str],
+    network_os: str,
+    username: str,
+    password: str,
+) -> Dict[str, Any]:
+    """Build an ansible inventory for multiple devices.
+
+    :param device_to_ip: Mapping of device name to its management IP
+    :param network_os: The network OS
+    :param username: Device username
+    :param password: Device password
+    :returns: The inventory for all devices under group 'all'
+    """
+    hosts: Dict[str, Any] = {}
+
+    for device_name, ip_address in device_to_ip.items():
+        ports = calculate_ports(ip_address)
+        host_key = _sanitize_host_key(device_name)
+        hosts[host_key] = {
+            "ansible_become": False,
+            "ansible_host": host,
+            "ansible_user": username,
+            "ansible_password": password,
+            "ansible_port": ports["ssh_port"],
+            "ansible_httpapi_port": ports["http_port"],
+            "ansible_connection": "ansible.netcommon.network_cli",
+            "ansible_network_cli_ssh_type": "libssh",
+            "ansible_python_interpreter": "python",
+            "ansible_network_import_modules": True,
+        }
+
+    return {"all": {"hosts": hosts, "vars": {"ansible_network_os": network_os}}}
+
+
+def _sanitize_host_key(name: str) -> str:
+    """Return a safe inventory host key from an arbitrary device name."""
+    return "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in name)
 
 
 def playbook(hosts: str, role: str) -> List[Dict[str, object]]:


### PR DESCRIPTION
Plan - 
The tool should be able to create one lab with all the `core versions we want to test = each appliance in lab`
The lab would have muliple appliance with exact same configuration aka multi.yaml
The tests for muliple core versions should run within a lab, there should not be one lab per core-version (dirty approcah)

Challenges -
How to find and distribute dhcp leased Ip addresses to Muliple GHA workflows running core specific tests
When to kill lab how to detect that all tests are over (GHA can do) but tricky
#TODO




cmd
`python3 -m pytest  tests/integration --integration-tests-path tests/integration/targets --cml-lab tests/integration/labs/multi.yaml --color=yes -n 1 --log-level WARNING -vvvvv --role-includes=ios_acls`

.vscode/launch.json
```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Pytest Integration Tests",
      "type": "python",
      "request": "launch",
      "module": "pytest",
      "args": [
        "tests/integration",
        "--integration-tests-path",
        "tests/integration/targets",
        "--cml-lab",
        "tests/integration/labs/multi.yaml",
        "--color=yes",
        "-n",
        "1",
        "--log-level",
        "WARNING",
        "-vvv",
        "--role-excludes=snmp_server"
      ],
      "cwd": "/...collections/ansible_collections/cisco/ios",
      "console": "integratedTerminal",
      "justMyCode": false,
      "env": {
        "PYTHONPATH": "${workspaceFolder}/src"
      }
    }
  ]
}
```

/...collections/ansible_collections/cisco/ios/tests/integration/labs/multi.yaml
```yaml
annotations:
  - border_color: '#808080FF'
    border_style: ''
    color: '#FFFFFFFF'
    line_end: null
    line_start: null
    thickness: 1
    type: line
    x1: -320.0
    y1: 240.0
    x2: -320.0
    y2: 240.0
    z_index: 0
nodes:
  - boot_disk_size: null
    configuration: &conf |-
      service timestamps debug datetime msec
      service timestamps log datetime msec
      platform qfp utilization monitor load 80
      platform punt-keepalive disable-kernel-core
      platform sslvpn use-pd
      platform console serial
      !
      hostname cisco
      !
      boot-start-marker
      boot-end-marker
      !
      !
      no aaa new-model
      !
      !
      !
      !
      !
      !
      !
      !
      !
      !
      !
      !
      ip domain name ansible.com
      !
      !
      !
      login on-success log
      !
      !
      subscriber templating
      !
      pae
      !
      !
      crypto pki trustpoint SLA-TrustPoint
       enrollment pkcs12
       revocation-check crl
       hash sha256
      !
      !
      crypto pki certificate chain SLA-TrustPoint
       certificate ca 01
        30820321 30820209 A0030201 02020101 300D0609 2A864886 F70D0101 0B050030
        32310E30 0C060355 040A1305 43697363 6F312030 1E060355 04031317 43697363
        6F204C69 63656E73 696E6720 526F6F74 20434130 1E170D31 33303533 30313934
        3834375A 170D3338 30353330 31393438 34375A30 32310E30 0C060355 040A1305
        43697363 6F312030 1E060355 04031317 43697363 6F204C69 63656E73 696E6720
        526F6F74 20434130 82012230 0D06092A 864886F7 0D010101 05000382 010F0030
        82010A02 82010100 A6BCBD96 131E05F7 145EA72C 2CD686E6 17222EA1 F1EFF64D
        CBB4C798 212AA147 C655D8D7 9471380D 8711441E 1AAF071A 9CAE6388 8A38E520
        1C394D78 462EF239 C659F715 B98C0A59 5BBB5CBD 0CFEBEA3 700A8BF7 D8F256EE
        4AA4E80D DB6FD1C9 60B1FD18 FFC69C96 6FA68957 A2617DE7 104FDC5F EA2956AC
        7390A3EB 2B5436AD C847A2C5 DAB553EB 69A9A535 58E9F3E3 C0BD23CF 58BD7188
        68E69491 20F320E7 948E71D7 AE3BCC84 F10684C7 4BC8E00F 539BA42B 42C68BB7
        C7479096 B4CB2D62 EA2F505D C7B062A4 6811D95B E8250FC4 5D5D5FB8 8F27D191
        C55F0D76 61F9A4CD 3D992327 A8BB03BD 4E6D7069 7CBADF8B DF5F4368 95135E44
        DFC7C6CF 04DD7FD1 02030100 01A34230 40300E06 03551D0F 0101FF04 04030201
        06300F06 03551D13 0101FF04 05300301 01FF301D 0603551D 0E041604 1449DC85
        4B3D31E5 1B3E6A17 606AF333 3D3B4C73 E8300D06 092A8648 86F70D01 010B0500
        03820101 00507F24 D3932A66 86025D9F E838AE5C 6D4DF6B0 49631C78 240DA905
        604EDCDE FF4FED2B 77FC460E CD636FDB DD44681E 3A5673AB 9093D3B1 6C9E3D8B
        D98987BF E40CBD9E 1AECA0C2 2189BB5C 8FA85686 CD98B646 5575B146 8DFC66A8
        467A3DF4 4D565700 6ADF0F0D CF835015 3C04FF7C 21E878AC 11BA9CD2 55A9232C
        7CA7B7E6 C1AF74F6 152E99B7 B1FCF9BB E973DE7F 5BDDEB86 C71E3B49 1765308B
        5FB0DA06 B92AFE7F 494E8A9E 07B85737 F3A58BE1 1A48A229 C37C1E69 39F08678
        80DDCD16 D6BACECA EEBC7CF9 8428787B 35202CDC 60E4616A B623CDBD 230E3AFB
        418616A9 4093E049 4D10AB75 27E86F73 932E35B5 8862FDAE 0275156F 719BB2F0
        D697DF7F 28
              quit
      !
      !
      license udi pid C8000V sn 9EGHOCL6VW2
      memory free low-watermark processor 201711
      diagnostic bootup level minimal
      !
      !
      !
      username ansible privilege 15 secret 9 $9$VslpRow9omMy..$5zvxcxrJqLeDd0qEe.5FANSAeLgz9LLAzMiAjieb/nc
      !
      redundancy
      !
      !
      !
      !
      !
      !
      !
      !
      interface GigabitEthernet1
       ip address dhcp
       no shutdown
       negotiation auto
      !
      interface GigabitEthernet2
       no ip address
       shutdown
       negotiation auto
      !
      interface GigabitEthernet3
       no ip address
       shutdown
       negotiation auto
      !
      interface GigabitEthernet4
       no ip address
       shutdown
       negotiation auto
      !
      ip forward-protocol nd
      !
      no ip http server
      ip http secure-server
      ip ssh bulk-mode 131072
      !
      !
      !
      !
      !
      control-plane
      !
      !
      line con 0
       stopbits 1
      line aux 0
      line vty 0 4
       login local
       transport input ssh
      !
      !
      !
      !
      !
      !
      !
      end
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n0
    image_definition: null
    label: ios_core_devel
    node_definition: cat8000v
    parameters: {}
    ram: null
    tags: []
    x: -1200
    y: -40
    interfaces:
      - id: i0
        label: Loopback0
        type: loopback
      - id: i1
        label: GigabitEthernet1
        slot: 0
        type: physical
      - id: i2
        label: GigabitEthernet2
        slot: 1
        type: physical
      - id: i3
        label: GigabitEthernet3
        slot: 2
        type: physical
      - id: i4
        label: GigabitEthernet4
        slot: 3
        type: physical
  - boot_disk_size: null
    configuration: *conf
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n1
    image_definition: null
    label: ios_core_milestone
    node_definition: cat8000v
    parameters: {}
    ram: null
    tags: []
    x: -1440
    y: -40
    interfaces:
      - id: i0
        label: Loopback0
        type: loopback
      - id: i1
        label: GigabitEthernet1
        slot: 0
        type: physical
      - id: i2
        label: GigabitEthernet2
        slot: 1
        type: physical
      - id: i3
        label: GigabitEthernet3
        slot: 2
        type: physical
      - id: i4
        label: GigabitEthernet4
        slot: 3
        type: physical
  - boot_disk_size: null
    configuration: *conf
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n2
    image_definition: null
    label: ios_core_2_18
    node_definition: cat8000v
    parameters: {}
    ram: null
    tags: []
    x: -1520
    y: 120
    interfaces:
      - id: i0
        label: Loopback0
        type: loopback
      - id: i1
        label: GigabitEthernet1
        slot: 0
        type: physical
      - id: i2
        label: GigabitEthernet2
        slot: 1
        type: physical
      - id: i3
        label: GigabitEthernet3
        slot: 2
        type: physical
      - id: i4
        label: GigabitEthernet4
        slot: 3
        type: physical
  - boot_disk_size: null
    configuration: *conf
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n3
    image_definition: null
    label: ios_core_2_16
    node_definition: cat8000v
    parameters: {}
    ram: null
    tags: []
    x: -1440
    y: 280
    interfaces:
      - id: i0
        label: Loopback0
        type: loopback
      - id: i1
        label: GigabitEthernet1
        slot: 0
        type: physical
      - id: i2
        label: GigabitEthernet2
        slot: 1
        type: physical
      - id: i3
        label: GigabitEthernet3
        slot: 2
        type: physical
      - id: i4
        label: GigabitEthernet4
        slot: 3
        type: physical
  - boot_disk_size: null
    configuration: *conf
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n4
    image_definition: null
    label: ios_core_2_19
    node_definition: cat8000v
    parameters: {}
    ram: null
    tags: []
    x: -1200
    y: 280
    interfaces:
      - id: i0
        label: Loopback0
        type: loopback
      - id: i1
        label: GigabitEthernet1
        slot: 0
        type: physical
      - id: i2
        label: GigabitEthernet2
        slot: 1
        type: physical
      - id: i3
        label: GigabitEthernet3
        slot: 2
        type: physical
      - id: i4
        label: GigabitEthernet4
        slot: 3
        type: physical
  - boot_disk_size: null
    configuration: []
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n5
    image_definition: null
    label: unmanaged-switch-0
    node_definition: unmanaged_switch
    parameters: {}
    ram: null
    tags: []
    x: -1320
    y: 120
    interfaces:
      - id: i0
        label: port0
        slot: 0
        type: physical
      - id: i1
        label: port1
        slot: 1
        type: physical
      - id: i2
        label: port2
        slot: 2
        type: physical
      - id: i3
        label: port3
        slot: 3
        type: physical
      - id: i4
        label: port4
        slot: 4
        type: physical
      - id: i5
        label: port5
        slot: 5
        type: physical
      - id: i6
        label: port6
        slot: 6
        type: physical
      - id: i7
        label: port7
        slot: 7
        type: physical
  - boot_disk_size: null
    configuration: []
    cpu_limit: null
    cpus: null
    data_volume: null
    hide_links: false
    id: n6
    image_definition: null
    label: ext-conn-0
    node_definition: external_connector
    parameters: {}
    ram: null
    tags: []
    x: -640
    y: 120
    interfaces:
      - id: i0
        label: port
        slot: 0
        type: physical
links:
  - id: l0
    n1: n5
    n2: n6
    i1: i0
    i2: i0
    conditioning: {}
    label: unmanaged-switch-0-port0<->ext-conn-0-port
  - id: l1
    n1: n5
    n2: n0
    i1: i1
    i2: i1
    conditioning: {}
    label: unmanaged-switch-0-port1<->ios_core_devel-GigabitEthernet1
  - id: l2
    n1: n5
    n2: n1
    i1: i2
    i2: i1
    conditioning: {}
    label: unmanaged-switch-0-port2<->ios_core_milestone-GigabitEthernet1
  - id: l3
    n1: n5
    n2: n2
    i1: i3
    i2: i1
    conditioning: {}
    label: unmanaged-switch-0-port3<->ios_core_2_18-GigabitEthernet1
  - id: l4
    n1: n5
    n2: n3
    i1: i4
    i2: i1
    conditioning: {}
    label: unmanaged-switch-0-port4<->ios_core_2_16-GigabitEthernet1
  - id: l5
    n1: n5
    n2: n4
    i1: i5
    i2: i1
    conditioning: {}
    label: unmanaged-switch-0-port5<->ios_core_2_19-GigabitEthernet1
lab:
  description: 'Upstream test lab for cisco.ios'
  notes: 'Upstream test lab for cisco.ios'
  title: cisco.ios.ios
  version: 0.2.2
```
tology view in CML
<img width="1228" height="507" alt="image" src="https://github.com/user-attachments/assets/fa3c3010-87b6-46de-876f-33e6abc615b4" />

